### PR TITLE
Allow optional value as NULL when default is set

### DIFF
--- a/src/Cli/Handler/GenerateCommandHandler.php
+++ b/src/Cli/Handler/GenerateCommandHandler.php
@@ -116,7 +116,7 @@ final class GenerateCommandHandler
             $questioner = new UsingDefaultsQuestioner();
         }
 
-        $configuration = $questioner->interact($configurators, !$args->getOption('all'), $defaults);
+        $questionsSet = $questioner->interact($configurators, !$args->getOption('all'), $defaults);
 
         if (!$disableDefaults) {
             file_put_contents(
@@ -124,18 +124,20 @@ final class GenerateCommandHandler
                 json_encode(
                     [
                         'profile' => $profile,
-                        'defaults' => $configuration,
+                        'defaults' => $questionsSet->getAnswers(),
                     ],
                     JSON_PRETTY_PRINT
                 )
             );
         }
 
+        $values = $questionsSet->getValues();
+
         foreach ($configurators as $finalizer) {
-            $finalizer->finalizeConfiguration($configuration);
+            $finalizer->finalizeConfiguration($values);
         }
 
-        return $configuration;
+        return $values;
     }
 
     private function processSavedDefaults($profile, $disableDefaults = false)

--- a/src/Cli/Handler/ProfileCommandHandler.php
+++ b/src/Cli/Handler/ProfileCommandHandler.php
@@ -190,6 +190,6 @@ final class ProfileCommandHandler
             $configurator->interact($questions);
         }
 
-        return $questions->all();
+        return $questions->getValues();
     }
 }

--- a/src/Configurator/GeneralConfigurator.php
+++ b/src/Configurator/GeneralConfigurator.php
@@ -112,16 +112,16 @@ final class GeneralConfigurator implements Configurator
                 function ($value) {
                     return trim($value, '/');
                 }
-            )->markOptional()
+            )->markOptional('.')
         );
     }
 
     public function finalizeConfiguration(array &$configuration)
     {
-        if ('' !== $configuration['src_dir']) {
-            $configuration['src_dir_norm'] = $configuration['src_dir'].'/';
-        } else {
+        if ('' === (string) $configuration['src_dir']) {
             $configuration['src_dir_norm'] = '';
+        } else {
+            $configuration['src_dir_norm'] = $configuration['src_dir'].'/';
         }
     }
 

--- a/src/Configurator/PhpCsConfigurator.php
+++ b/src/Configurator/PhpCsConfigurator.php
@@ -29,10 +29,10 @@ final class PhpCsConfigurator implements Configurator
             'php_cs_enabled_fixers',
             Question::ask(
                 'PHP-CS Fixers',
-                '',
+                'none',
                 function ($value) {
-                    if ('' === $value) {
-                        return '';
+                    if ('none' === $value) {
+                        return $value;
                     }
 
                     $fixers = $this->splitValues($value);
@@ -58,17 +58,17 @@ final class PhpCsConfigurator implements Configurator
 
                     return $value;
                 }
-            )->markOptional() // Optional, as this should be configured using a defaults value.
+            )->markOptional('none') // Optional, as this should be configured using a defaults value.
         );
 
         $questions->communicate(
             'php_cs_disabled_fixers',
             Question::ask(
                 'PHP-CS Disabled fixers',
-                '',
+                'none',
                 function ($value) {
-                    if ('' === $value) {
-                        return '';
+                    if ('none' === $value) {
+                        return $value;
                     }
 
                     $fixers = $this->splitValues($value);
@@ -84,7 +84,7 @@ final class PhpCsConfigurator implements Configurator
 
                     return $value;
                 }
-            )->markOptional() // Optional, as this should be configured using a defaults value.
+            )->markOptional('none') // Optional, as this should be configured using a defaults value.
         );
 
         $questions->communicate(
@@ -106,16 +106,16 @@ final class PhpCsConfigurator implements Configurator
 
         // Finder questions.
         $questions->communicate('php_cs_finder_path', Question::ask('PHP-CS Finder {path}', 'src', false)->markOptional());
-        $questions->communicate('php_cs_finder_not_path', Question::ask('PHP-CS Finder {not path}', false)->markOptional());
-        $questions->communicate('php_cs_finder_exclude', Question::ask('PHP-CS Finder {exclude dirs}', false)->markOptional());
+        $questions->communicate('php_cs_finder_not_path', Question::ask('PHP-CS Finder {not path}', '!*', false)->markOptional('!*'));
+        $questions->communicate('php_cs_finder_exclude', Question::ask('PHP-CS Finder {exclude dirs}', '!*', false)->markOptional('!*'));
 
-        $questions->communicate('php_cs_finder_name', Question::ask('PHP-CS Finder {name}', false)->markOptional());
-        $questions->communicate('php_cs_finder_not_name', Question::ask('PHP-CS Finder {not name}', false)->markOptional());
+        $questions->communicate('php_cs_finder_name', Question::ask('PHP-CS Finder {name}', '*', false)->markOptional('*'));
+        $questions->communicate('php_cs_finder_not_name', Question::ask('PHP-CS Finder {not name}', '!*', false)->markOptional('!*'));
 
-        $questions->communicate('php_cs_finder_contains', Question::ask('PHP-CS Finder {contains}', false)->markOptional());
-        $questions->communicate('php_cs_finder_not_contains', Question::ask('PHP-CS Finder {not contains}', false)->markOptional());
+        $questions->communicate('php_cs_finder_contains', Question::ask('PHP-CS Finder {contains}', '*', false)->markOptional('*'));
+        $questions->communicate('php_cs_finder_not_contains', Question::ask('PHP-CS Finder {not contains}', '!*', false)->markOptional('!*'));
 
-        $questions->communicate('php_cs_finder_depth', Question::ask('PHP-CS Finder {depth}', false)->markOptional());
+        $questions->communicate('php_cs_finder_depth', Question::ask('PHP-CS Finder {depth}', '*', false)->markOptional('*'));
     }
 
     public function finalizeConfiguration(array &$configuration)

--- a/src/Generator/SkeletonDancerInitGenerator.php
+++ b/src/Generator/SkeletonDancerInitGenerator.php
@@ -141,6 +141,6 @@ final class SkeletonDancerInitGenerator implements Generator
             $configurator->interact($questions);
         }
 
-        return $questions->all();
+        return $questions->getAnswers();
     }
 }

--- a/src/Questioner.php
+++ b/src/Questioner.php
@@ -18,7 +18,7 @@ interface Questioner
      * @param bool           $skipOptional
      * @param array          $defaults
      *
-     * @return array
+     * @return QuestionsSet
      */
     public function interact(array $configurators, $skipOptional = true, array $defaults = []);
 }

--- a/src/Questioner/InteractiveQuestioner.php
+++ b/src/Questioner/InteractiveQuestioner.php
@@ -11,7 +11,6 @@
 
 namespace Rollerworks\Tools\SkeletonDancer\Questioner;
 
-use Rollerworks\Tools\SkeletonDancer\Configurator;
 use Rollerworks\Tools\SkeletonDancer\Questioner;
 use Rollerworks\Tools\SkeletonDancer\QuestionsSet;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -29,11 +28,7 @@ final class InteractiveQuestioner implements Questioner
     }
 
     /**
-     * @param Configurator[] $configurators
-     * @param bool           $skipOptional
-     * @param array          $defaults
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function interact(array $configurators, $skipOptional = true, array $defaults = [])
     {
@@ -47,6 +42,6 @@ final class InteractiveQuestioner implements Questioner
             $configurator->interact($questions);
         }
 
-        return $questions->all();
+        return $questions;
     }
 }

--- a/src/Questioner/UsingDefaultsQuestioner.php
+++ b/src/Questioner/UsingDefaultsQuestioner.php
@@ -47,7 +47,7 @@ final class UsingDefaultsQuestioner implements Questioner
             $this->currentQuestion = null;
             $this->currentConfigurator = null;
 
-            return $questions->all();
+            return $questions;
         } catch (\Exception $e) {
             if (null !== $this->currentQuestion) {
                 throw new \RuntimeException(

--- a/src/QuestionsSet.php
+++ b/src/QuestionsSet.php
@@ -19,6 +19,11 @@ final class QuestionsSet
     private $answers = [];
 
     /**
+     * @var array
+     */
+    private $values = [];
+
+    /**
      * @var \Closure
      */
     private $communicator;
@@ -47,7 +52,7 @@ final class QuestionsSet
         }
 
         $default = isset($this->defaults[$name]) ? $this->defaults[$name] : null;
-        $default = $this->resolveDefault($question, $this->answers, $default);
+        $default = $this->resolveDefault($question, $this->values, $default);
 
         if ($this->skipOptional && $question->isOptional()) {
             $value = $default;
@@ -57,6 +62,7 @@ final class QuestionsSet
         }
 
         if (null !== $name) {
+            $this->values[$name] = $question->getNormalizer() ? call_user_func($question->getNormalizer(), $value) : $value;
             $this->answers[$name] = $value;
         }
 
@@ -68,6 +74,8 @@ final class QuestionsSet
         if (array_key_exists($name, $this->answers)) {
             throw new \InvalidArgumentException(sprintf('Question with name "%s" already exists in the QuestionsSet.', $name));
         }
+
+        $this->values[$name] = $value;
 
         return $this->answers[$name] = $value;
     }
@@ -82,9 +90,14 @@ final class QuestionsSet
         return array_key_exists($name, $this->answers);
     }
 
-    public function all()
+    public function getAnswers()
     {
         return $this->answers;
+    }
+
+    public function getValues()
+    {
+        return $this->values;
     }
 
     /**

--- a/tests/Configurator/ConfiguratorTestCase.php
+++ b/tests/Configurator/ConfiguratorTestCase.php
@@ -94,7 +94,7 @@ abstract class ConfiguratorTestCase extends \PHPUnit_Framework_TestCase
         $this->initConfigurator();
 
         $questioner = new UsingDefaultsQuestioner();
-        $configuration = $questioner->interact($this->configurators, true, $values);
+        $configuration = $questioner->interact($this->configurators, true, $values)->getValues();
 
         foreach ($this->configurators as $finalizer) {
             $finalizer->finalizeConfiguration($configuration);

--- a/tests/Generator/GeneratorTestCase.php
+++ b/tests/Generator/GeneratorTestCase.php
@@ -94,7 +94,7 @@ abstract class GeneratorTestCase extends \PHPUnit_Framework_TestCase
         $this->initGenerator();
 
         $questioner = new UsingDefaultsQuestioner();
-        $configuration = $questioner->interact($this->configurators, true, $values);
+        $configuration = $questioner->interact($this->configurators, true, $values)->getValues();
 
         foreach ($this->configurators as $finalizer) {
             $finalizer->finalizeConfiguration($configuration);

--- a/tests/Questioner/InteractiveQuestionerTest.php
+++ b/tests/Questioner/InteractiveQuestionerTest.php
@@ -53,7 +53,7 @@ final class InteractiveQuestionerTest extends \PHPUnit_Framework_TestCase
             ),
         ];
 
-        $answers = $questioner->interact($configurators);
+        $answers = $questioner->interact($configurators)->getValues();
 
         $this->assertSame(['name' => 'Dancer', 'namespace' => 'Rollerworks\Something'], $answers);
     }
@@ -79,7 +79,7 @@ final class InteractiveQuestionerTest extends \PHPUnit_Framework_TestCase
             ),
         ];
 
-        $answers = $questioner->interact($configurators);
+        $answers = $questioner->interact($configurators)->getValues();
 
         $this->assertSame(['name' => 'Dancer', 'path' => '/'], $answers);
     }
@@ -105,7 +105,7 @@ final class InteractiveQuestionerTest extends \PHPUnit_Framework_TestCase
             ),
         ];
 
-        $answers = $questioner->interact($configurators, false);
+        $answers = $questioner->interact($configurators, false)->getValues();
 
         $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $answers);
     }
@@ -132,7 +132,7 @@ final class InteractiveQuestionerTest extends \PHPUnit_Framework_TestCase
             ),
         ];
 
-        $answers = $questioner->interact($configurators, true, ['path' => 'src/']);
+        $answers = $questioner->interact($configurators, true, ['path' => 'src/'])->getValues();
 
         $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $answers);
     }

--- a/tests/QuestionsSetTest.php
+++ b/tests/QuestionsSetTest.php
@@ -40,7 +40,7 @@ final class QuestionsSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Dancer', $questions->communicate('name', $question1));
         $this->assertEquals('src/', $questions->communicate('path', $question2));
 
-        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->all());
+        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->getAnswers());
         $this->assertEquals('Dancer', $questions->get('name'));
         $this->assertNull($questions->get('foo'));
 
@@ -67,7 +67,7 @@ final class QuestionsSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Dancer', $questions->communicate('name', $question1));
         $this->assertEquals('/', $questions->communicate('path', $question2));
-        $this->assertSame(['name' => 'Dancer', 'path' => '/'], $questions->all());
+        $this->assertSame(['name' => 'Dancer', 'path' => '/'], $questions->getAnswers());
     }
 
     /**
@@ -94,7 +94,36 @@ final class QuestionsSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Dancer', $questions->communicate('name', $question1));
         $this->assertEquals('src/', $questions->communicate('path', $question2));
-        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->all());
+        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->getAnswers());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_optional_questions_to_be_null()
+    {
+        $question1 = Question::ask('Name');
+        $question2 = Question::ask('Path', '/')->markOptional('/');
+
+        $questions = new QuestionsSet(
+            function (SfQuestion $question) use ($question1, $question2) {
+                if ($question->getQuestion() === $question1->getLabel()) {
+                    return 'Dancer';
+                }
+
+                if ($question->getQuestion() === $question2->getLabel()) {
+                    return '/';
+                }
+            },
+            [],
+            false
+        );
+
+        $this->assertEquals('Dancer', $questions->communicate('name', $question1));
+        $this->assertEquals('/', $questions->communicate('path', $question2));
+
+        $this->assertSame(['name' => 'Dancer', 'path' => null], $questions->getValues());
+        $this->assertSame(['name' => 'Dancer', 'path' => '/'], $questions->getAnswers());
     }
 
     /**
@@ -121,7 +150,7 @@ final class QuestionsSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Dancer', $questions->communicate('name', $question1));
         $this->assertEquals('Dancer/', $questions->communicate('path', $question2));
-        $this->assertSame(['name' => 'Dancer', 'path' => 'Dancer/'], $questions->all());
+        $this->assertSame(['name' => 'Dancer', 'path' => 'Dancer/'], $questions->getAnswers());
     }
 
     /**
@@ -141,7 +170,7 @@ final class QuestionsSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Dancer', $questions->communicate('name', $question1));
         $this->assertEquals('src/', $questions->communicate('path', $question2));
-        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->all());
+        $this->assertSame(['name' => 'Dancer', 'path' => 'src/'], $questions->getAnswers());
     }
 
     /**


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Bug Fix?     |n  |
|New Feature? |yes|
|BC Breaks?   |yes|
|Deprecations?|no |
|Tests Pass?  |yes|
|Fixed Tickets|   |
|License      | MIT |

When interactive-mode is enabled for all questions it's not possible to leave an optional value empty.
The SymfonyStyle forces that a value is required and even then when there is an default leaving the value empty, will use the default!

This change makes it possible to mark a value as option by treading some values as NULL.
For example:

* `.` for the `src_dir` will transformed to NULL.
* `*` for php_cs_finder_name will be transformed to NULL.

Note that a question marked as optional requires eg. a default or value for the `markOptional` method.
Else an exception gets thrown.